### PR TITLE
Marked as 'pablic' default ScrollSegmentDelegate implementation

### DIFF
--- a/Example/Pods/ScrollSegmentsSwift/ScrollSegmentsSwift/Classes/ScrollSegmentsSwift.swift
+++ b/Example/Pods/ScrollSegmentsSwift/ScrollSegmentsSwift/Classes/ScrollSegmentsSwift.swift
@@ -26,7 +26,8 @@ public protocol ScrollSegmentDelegate: class {
     func segmentSelected(index: Int)
     func scrollSegmentsLoaded()
 }
-extension ScrollSegmentDelegate {
+
+public extension ScrollSegmentDelegate {
     func scrollSegmentsLoaded() { }
 }
 


### PR DESCRIPTION
Marked as 'pablic' default ScrollSegmentDelegate implementation to have an ability not implement 'func scrollSegmentsLoaded()' when it doesn't need